### PR TITLE
Beavertown now corporate

### DIFF
--- a/source/data.json
+++ b/source/data.json
@@ -19,7 +19,8 @@
 	  {
 	    "link": "http://www.beavertownbrewery.co.uk/",
 	    "name": "Beavertown",
-	    "status": "corporate"
+	    "status": "corporate",
+	    "citation":"https://www.theguardian.com/business/2022/sep/07/london-craft-brewer-beavertown-sells-up-fully-to-heineken"
 	  },
 	  {
 	    "citation": "https://www.brewdog.com/lowdown/blog/nailing-our-colours-to-the-motherfucking-mast",

--- a/source/data.json
+++ b/source/data.json
@@ -19,7 +19,7 @@
 	  {
 	    "link": "http://www.beavertownbrewery.co.uk/",
 	    "name": "Beavertown",
-	    "status": "craft"
+	    "status": "corporate"
 	  },
 	  {
 	    "citation": "https://www.brewdog.com/lowdown/blog/nailing-our-colours-to-the-motherfucking-mast",


### PR DESCRIPTION
https://www.theguardian.com/business/2022/sep/07/london-craft-brewer-beavertown-sells-up-fully-to-heineken